### PR TITLE
fixed up clippy warnings, ran cargo fmt

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,30 +21,28 @@ impl Args {
         let mut file_content: String = String::new();
         let file_content_ci: String = String::new();
         if args.len() >= 3 {
-            for i in 1..args.len() - 2 {
-                if &args[i] == "--help" {
+            for arg in args.iter().take(args.len() - 2).skip(1) {
+                if arg == "--help" {
                     option.push(String::from("-h"));
-                } else if &args[i] == "--future" {
+                } else if arg == "--future" {
                     option.push(String::from("-f"));
-                }else {
-                    option.push(args[i].clone());
+                } else {
+                    option.push(arg.clone());
                 }
             }
-            file = String::from(args[args.len() - 1].clone());
+            file = args[args.len() - 1].clone();
             recurse_options_parser(&file, args.len().try_into().unwrap(), &mut file_content);
             file_content = fs::read_to_string(&file)
                 .expect("Something went wrong readin file, possibly non existant file?");
-            pattern = String::from(args[args.len() - 2].clone());
+            pattern = args[args.len() - 2].clone();
+        } else if args.len() > 1 && (args[1] == "--help" || args[1] == "-h") {
+            option.push(String::from("-h"));
+        } else if args.len() > 1 && (args[1] == "--future" || args[1] == "-f") {
+            option.push(String::from("-f"));
         } else {
-            if args.len() > 1 && (args[1] == "--help" || args[1] == "-h") {
-                option.push(String::from("-h"));
-            } else if args.len() > 1 && (args[1] == "--future" || args[1] == "-f"){
-                option.push(String::from("-f"));
-            } else {
-                println!("Not enough option/fields, please use --help to see usage of this tool!");
-                option.push(String::from("-invalid"));
-                //Intentionally add unrecoginsable options to give correct error messages.
-            }
+            println!("Not enough option/fields, please use --help to see usage of this tool!");
+            option.push(String::from("-invalid"));
+            //Intentionally add unrecoginsable options to give correct error messages.
         }
         Args {
             option,
@@ -62,10 +60,10 @@ fn main() {
         -1 => {
             println!("Invalid options detected!");
             println!("use option --help to see all valid/possible options.");
-            println!("use option --future to see all options that will be added in the future."); 
+            println!("use option --future to see all options that will be added in the future.");
         }
         0 => {
-            modules::modules::print_help();
+            modules::output::print_help();
         }
         1 => {
             //Normal strcict search
@@ -78,7 +76,7 @@ fn main() {
             //Do nothing as invalid options detected
         }
         4 => {
-            modules::modules::print_future(); // future flags 
+            modules::output::print_future(); // future flags
         }
         _ => {
             panic!("Something went wrong on our side.");
@@ -86,13 +84,16 @@ fn main() {
     }
 }
 
-fn recurse_options_parser(myfile: &String, n_args:i32, file_content: &mut String){
-    for file in WalkDir::new(myfile).into_iter().filter_map(|file| file.ok()) {
+fn recurse_options_parser(myfile: &String, n_args: i32, file_content: &mut String) {
+    for file in WalkDir::new(myfile)
+        .into_iter()
+        .filter_map(|file| file.ok())
+    {
         if file.metadata().unwrap().is_file() {
             println!("{}", file.path().display());
             if n_args >= 3 {
                 let content = fs::read_to_string(&file.path())
-                .expect("Something went wrong readin file, possibly non existant file?");
+                    .expect("Something went wrong readin file, possibly non existant file?");
                 file_content.push_str(&content);
             }
         }
@@ -125,8 +126,8 @@ fn options_parser() -> (i32, Args) {
     }
     if args_struct.option.contains(&String::from("-ci")) {
         detected_options += 1;
-        args_struct.file_content_ci = args_struct.file_content.to_lowercase().clone();
-        args_struct.pattern = args_struct.pattern.to_lowercase().to_string();
+        args_struct.file_content_ci = args_struct.file_content.to_lowercase();
+        args_struct.pattern = args_struct.pattern.to_lowercase();
     }
     if args_struct.option.contains(&String::from("-h")) {
         detected_options += 1;
@@ -140,5 +141,5 @@ fn options_parser() -> (i32, Args) {
     if detected_options < args_struct.option.len() {
         ret = -1;
     }
-    return (ret, args_struct);
+    (ret, args_struct)
 }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,2 +1,2 @@
-pub mod modules;
+pub mod output;
 pub mod stringmatch;

--- a/src/modules/output.rs
+++ b/src/modules/output.rs
@@ -1,6 +1,5 @@
 use colored::Colorize;
 
-
 pub fn print_logo() {
     //prints logo as a raw string, did not want to bloat package size by using ascii printer.
 
@@ -18,11 +17,19 @@ pub fn print_logo() {
 
 pub fn print_help() {
     print_logo();
-    println!("{}","\tGeneral usage : executable -option1 -option2 -option3 patter_word filename".yellow());
-    println!("{}",
-        "NOTE : IF CONFLICTING OPTIONS EXISTS, ONES THAT APPEAR FIRST IN THIS HELP ARE EXECUTED.".red()
+    println!(
+        "{}",
+        "\tGeneral usage : executable -option1 -option2 -option3 patter_word filename".yellow()
     );
-    println!("{}","Note : Simple grep cannot support regex, it is merely a string matching algorithm".red());
+    println!(
+        "{}",
+        "NOTE : IF CONFLICTING OPTIONS EXISTS, ONES THAT APPEAR FIRST IN THIS HELP ARE EXECUTED."
+            .red()
+    );
+    println!(
+        "{}",
+        "Note : Simple grep cannot support regex, it is merely a string matching algorithm".red()
+    );
     println!();
     println!();
     println!("Valid Options : ");
@@ -36,11 +43,19 @@ pub fn print_help() {
 }
 pub fn print_future() {
     print_logo();
-    println!("{}","\tGeneral usage : executable -option1 -option2 -option3 patter_word filename".yellow());
-    println!("{}",
-        "NOTE : IF CONFLICTING OPTIONS EXISTS, ONES THAT APPEAR FIRST IN THIS HELP ARE EXECUTED.".red()
+    println!(
+        "{}",
+        "\tGeneral usage : executable -option1 -option2 -option3 patter_word filename".yellow()
     );
-    println!("{}","Note : Simple grep cannot support regex, it is merely a string matching algorithm".red());
+    println!(
+        "{}",
+        "NOTE : IF CONFLICTING OPTIONS EXISTS, ONES THAT APPEAR FIRST IN THIS HELP ARE EXECUTED."
+            .red()
+    );
+    println!(
+        "{}",
+        "Note : Simple grep cannot support regex, it is merely a string matching algorithm".red()
+    );
     println!();
     println!();
     println!("Future Options : ");
@@ -48,7 +63,12 @@ pub fn print_future() {
     println!(" '-r' : recurse search, searches all files in a given folder (only one layer)");
 }
 
-pub fn print_file_line(start: usize, end: usize, file_arr: &Vec<char>, overall_string : &mut String){
+pub fn print_file_line(
+    start: usize,
+    end: usize,
+    file_arr: &Vec<char>,
+    overall_string: &mut String,
+) {
     let mut line_start = start;
     let mut line_end = end;
     while line_start != 0 && file_arr[line_start] != '\n' {
@@ -58,15 +78,20 @@ pub fn print_file_line(start: usize, end: usize, file_arr: &Vec<char>, overall_s
         line_end += 1;
     }
 
-    let mut temp_string : String = String::new();
-    for i in line_start + 1..line_end{
+    let mut temp_string: String = String::new();
+    for (i, fa) in file_arr
+        .iter()
+        .enumerate()
+        .take(line_end)
+        .skip(line_start + 1)
+    {
         //-1 to ignore the ending new line, +1 to ignore starting newline
         if i >= start && i < end {
-             temp_string = format!("{}{}",temp_string,file_arr[i].to_string().blue());
+            temp_string = format!("{}{}", temp_string, fa.to_string().blue());
         } else {
-            temp_string = format!("{}{}",temp_string,file_arr[i]);
+            temp_string = format!("{}{}", temp_string, fa);
         }
     }
-    temp_string = format!("{}{}",temp_string,"\n");
+    temp_string = format!("{}{}", temp_string, "\n");
     overall_string.push_str(&temp_string);
 }

--- a/src/modules/stringmatch.rs
+++ b/src/modules/stringmatch.rs
@@ -1,4 +1,4 @@
-use super::modules::print_file_line;
+use super::output::print_file_line;
 use crate::Args;
 use std::collections::HashMap;
 
@@ -12,11 +12,11 @@ impl Table {
             shift_table: HashMap::new(),
         }
     }
-    fn preprocess_pattern(self: &mut Self, pattern: &String) {
+    fn preprocess_pattern(&mut self, pattern: &String) {
         for (i, item) in pattern.chars().enumerate() {
             if i != pattern.len() - 1 {
                 let value_ref = (*self).shift_table.entry(item).or_insert(0);
-                *value_ref = usize::try_from(pattern.len() - 1 - i).unwrap();
+                *value_ref = pattern.len() - 1 - i;
             }
         }
     }
@@ -41,20 +41,22 @@ fn horspool_algorithm(args_struct: &Args, table: &mut Table, strict: bool) {
         let mut right_start_index: usize = pat_len;
 
         //Below two is done as strings are not indexable by default in rust
-        let file_arr : Vec<char>;
-        let raw_file_arr : Vec<char> = args_struct.file_content.chars().collect();
-        if args_struct.file_content_ci.len()!=0{ //Will not be 0 only if ignore case option was passed.
-            file_arr = args_struct.file_content_ci.chars().collect();
-        }else{ //Default, original file
-            file_arr  = args_struct.file_content.chars().collect();
-        }
+        let raw_file_arr: Vec<char> = args_struct.file_content.chars().collect();
+
+        let file_arr: Vec<char> = if !args_struct.file_content_ci.is_empty() {
+            //Will not be 0 only if ignore case option was passed.
+            args_struct.file_content_ci.chars().collect()
+        } else {
+            //Default, original file
+            args_struct.file_content.chars().collect()
+        };
 
         let pat_arr: Vec<char> = args_struct.pattern.chars().collect(); //Automatically made lower case on ignore case option
                                                                         //Kept a seperate one for
                                                                         //file as we need to print
                                                                         //original final later to
                                                                         //show matches
-        let mut res_string : String = String::new();
+        let mut res_string: String = String::new();
 
         while right_start_index <= file_len {
             matched_chars = 0;
@@ -69,7 +71,7 @@ fn horspool_algorithm(args_struct: &Args, table: &mut Table, strict: bool) {
                     right_start_index - matched_chars,
                     right_start_index,
                     &raw_file_arr,
-                    &mut res_string
+                    &mut res_string,
                 );
                 right_start_index += pat_len;
             } else {
@@ -84,8 +86,5 @@ fn horspool_algorithm(args_struct: &Args, table: &mut Table, strict: bool) {
             }
         }
         println!("{}", res_string);
-    } else {
-        //Non strict, nearest matching
-        return;
     }
 }


### PR DESCRIPTION
Fixes #1 

Addressed all `clippy` warnings in this refactor, plus some minor `cargo fmt` format updates